### PR TITLE
Remove the no-longer used apiSecret from the api.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ pod 'TjekSDK/API', '5.0.0'
 
 In order to use our SDK you will need to sign up for a free [developer account](https://etilbudsavis.dk/developers). 
 
-This will give you an `API key`, `API secret`, and a `Track ID`. The SDK must be initialized with these 3 values in order to work.
+This will give you an `API key` and a `Track ID`. The SDK must be initialized with these values in order to work.
 
 ### Initialization via Config file 
 
@@ -98,7 +98,6 @@ do {
     TjekSDK.initialize(
         config: try .init(
             apiKey: "<your api key>",
-            apiSecret: "<your api secret>",
             trackId: .init(rawValue: "<your track id>")
         )
     )

--- a/Sources/TjekAPI/APIClient/APIClient.swift
+++ b/Sources/TjekAPI/APIClient/APIClient.swift
@@ -67,10 +67,14 @@ extension APIClient {
         self.clientHeaders["X-Token"] = authToken
     }
     
-    /// All future requests will use the specified APIKey/secret.
-    public func setAPIKey(_ apiKey: String, apiSecret: String) {
+    /// All future requests will use the specified APIKey
+    public func setAPIKey(_ apiKey: String) {
         self.clientHeaders["X-Api-Key"] = apiKey
-        self.clientHeaders["X-Api-Secret"] = apiSecret
+    }
+    
+    @available(*, deprecated, message: "apiSecret is no longer needed")
+    public func setAPIKey(_ apiKey: String, apiSecret: String) {
+        setAPIKey(apiKey)
     }
     
     /// All future requests will use the specified app version (in simVer).

--- a/Sources/TjekAPI/TjekAPI.swift
+++ b/Sources/TjekAPI/TjekAPI.swift
@@ -11,25 +11,23 @@ public class TjekAPI {
     
     public struct Config: Equatable {
         public var apiKey: String
-        public var apiSecret: String
         public var clientVersion: String
         public var baseURL: URL
         
-        public init(apiKey: String, apiSecret: String, clientVersion: String = shortBundleVersion(.main), baseURL: URL = URL(string: "https://squid-api.tjek.com")!) throws {
-            
+        public init(apiKey: String, clientVersion: String = shortBundleVersion(.main), baseURL: URL = URL(string: "https://squid-api.tjek.com")!) throws {
             guard !apiKey.isEmpty else {
                 struct APIKeyEmpty: Error { }
                 throw APIKeyEmpty()
             }
-            guard !apiSecret.isEmpty else {
-                struct APISecretEmpty: Error { }
-                throw APISecretEmpty()
-            }
             
             self.apiKey = apiKey
-            self.apiSecret = apiSecret
             self.clientVersion = clientVersion
             self.baseURL = baseURL
+        }
+        
+        @available(*, deprecated, message: "apiSecret is no longer needed")
+        public init(apiKey: String, apiSecret: String, clientVersion: String = shortBundleVersion(.main), baseURL: URL = URL(string: "https://squid-api.tjek.com")!) throws {
+            try self.init(apiKey: apiKey, clientVersion: clientVersion, baseURL: baseURL)
         }
     }
     
@@ -46,9 +44,8 @@ public class TjekAPI {
      Initialize the `shared` TjekAPI using the config plist file.
      Config file should be placed in your main bundle, with the name `TjekSDK-Config.plist`.
      
-     It must contain the following key/values:
+     It must contain the following key/value:
      - `apiKey: "<your api key>"`
-     - `apiSecret: "<your api secret>"`
      
      By default, `clientVersion` is the `CFBundleShortVersionString` of your `Bundle.main`.
      
@@ -77,11 +74,11 @@ public class TjekAPI {
     public var config: Config {
         didSet {
             v2.baseURL = config.baseURL.appendingPathComponent("v2")
-            v2.setAPIKey(config.apiKey, apiSecret: config.apiSecret)
+            v2.setAPIKey(config.apiKey)
             v2.setClientVersion(config.clientVersion)
             
             v4.baseURL = config.baseURL.appendingPathComponent("v4/rpc")
-            v4.setAPIKey(config.apiKey, apiSecret: config.apiSecret)
+            v4.setAPIKey(config.apiKey)
             v4.setClientVersion(config.clientVersion)
         }
     }
@@ -123,7 +120,7 @@ public class TjekAPI {
             }()
         )
         
-        v2.setAPIKey(config.apiKey, apiSecret: config.apiSecret)
+        v2.setAPIKey(config.apiKey)
         v2.setClientVersion(config.clientVersion)
         
         // Initialize v4 API
@@ -148,7 +145,7 @@ public class TjekAPI {
                 return decoder
             }()
         )
-        v4.setAPIKey(config.apiKey, apiSecret: config.apiSecret)
+        v4.setAPIKey(config.apiKey)
         v4.setClientVersion(config.clientVersion)
     }
 }
@@ -197,14 +194,12 @@ extension TjekAPI.Config {
         
         struct Config: Decodable {
             var apiKey: String
-            var apiSecret: String
         }
         
         let configFile = (try PropertyListDecoder().decode(Config.self, from: data))
         
         return try Self(
             apiKey: configFile.apiKey,
-            apiSecret: configFile.apiSecret,
             clientVersion: clientVersion
         )
     }
@@ -215,7 +210,6 @@ extension TjekAPI.Config {
         struct ConfigContainer: Decodable {
             struct Values: Decodable {
                 var key: String
-                var secret: String
             }
             var CoreAPI: Values
         }
@@ -224,7 +218,6 @@ extension TjekAPI.Config {
         
         return try Self(
             apiKey: fileValues.key,
-            apiSecret: fileValues.secret,
             clientVersion: clientVersion
         )
     }

--- a/Sources/TjekSDK/TjekSDK.swift
+++ b/Sources/TjekSDK/TjekSDK.swift
@@ -22,9 +22,14 @@ public struct TjekSDK {
             self.eventsTracker = eventsTracker
         }
         
-        public init(apiKey: String, apiSecret: String, trackId: TjekEventsTracker.Config.TrackId, clientVersion: String = shortBundleVersion(.main)) throws {
-            self.api = try .init(apiKey: apiKey, apiSecret: apiSecret, clientVersion: clientVersion)
+        public init(apiKey: String, trackId: TjekEventsTracker.Config.TrackId, clientVersion: String = shortBundleVersion(.main)) throws {
+            self.api = try .init(apiKey: apiKey, clientVersion: clientVersion)
             self.eventsTracker = try .init(trackId: trackId)
+        }
+        
+        @available(*, deprecated, message: "apiSecret is no longer needed")
+        public init(apiKey: String, apiSecret: String, trackId: TjekEventsTracker.Config.TrackId, clientVersion: String = shortBundleVersion(.main)) throws {
+            try self.init(apiKey: apiKey, trackId: trackId, clientVersion: clientVersion)
         }
     }
     

--- a/Tests/TjekAPITests/OpeningHoursTests.swift
+++ b/Tests/TjekAPITests/OpeningHoursTests.swift
@@ -18,7 +18,7 @@ class OpeningHoursTests: XCTestCase {
         let v2df = DateFormatter()
         v2df.locale = Locale(identifier: "en_US_POSIX")
         v2df.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
-        let decoder = TjekAPI(config: try .init(apiKey: "apiKey", apiSecret: "apiSecret")).v2.defaultDecoder
+        let decoder = TjekAPI(config: try .init(apiKey: "apiKey")).v2.defaultDecoder
         
         let fromDate = v2df.date(from: validFrom)!
         let toDate = v2df.date(from: validUntil)!

--- a/Tests/TjekAPITests/Resources/TjekSDK-Config.plist
+++ b/Tests/TjekAPITests/Resources/TjekSDK-Config.plist
@@ -4,7 +4,5 @@
 <dict>
 	<key>apiKey</key>
 	<string>&lt;sdk-demo api key&gt;</string>
-	<key>apiSecret</key>
-	<string>&lt;sdk-demo api secret&gt;</string>
 </dict>
 </plist>

--- a/Tests/TjekAPITests/TjekAPIConfigTests.swift
+++ b/Tests/TjekAPITests/TjekAPIConfigTests.swift
@@ -11,34 +11,30 @@ class TjekAPIConfigTests: XCTestCase {
         
         // 1. given
         let testKey = "test-key"
-        let testSecret = "test-secret"
         let testClientVersion = "1.2.3"
         let testURL = URL(string: "test-url")!
         let defaultURL = URL(string: "https://squid-api.tjek.com")!
         let defaultClientVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? ""
         
         // 2. when
-        let fullSettings = try TjekAPI.Config(apiKey: testKey, apiSecret: testSecret, clientVersion: testClientVersion, baseURL: testURL)
-        let minimalSettings = try TjekAPI.Config(apiKey: testKey, apiSecret: testSecret)
+        let fullSettings = try TjekAPI.Config(apiKey: testKey, clientVersion: testClientVersion, baseURL: testURL)
+        let minimalSettings = try TjekAPI.Config(apiKey: testKey)
         
         // 3. then
         XCTAssertEqual(fullSettings.apiKey, testKey)
-        XCTAssertEqual(fullSettings.apiSecret, testSecret)
         XCTAssertEqual(fullSettings.clientVersion, testClientVersion)
         XCTAssertEqual(fullSettings.baseURL, testURL)
         
         XCTAssertEqual(minimalSettings.apiKey, testKey)
-        XCTAssertEqual(minimalSettings.apiSecret, testSecret)
         XCTAssertEqual(minimalSettings.clientVersion, defaultClientVersion)
         XCTAssertEqual(minimalSettings.baseURL, defaultURL)
         
         // test empty input
-        XCTAssertThrowsError(try TjekAPI.Config(apiKey: "", apiSecret: "foo"))
-        XCTAssertThrowsError(try TjekAPI.Config(apiKey: "bar", apiSecret: ""))
+        XCTAssertThrowsError(try TjekAPI.Config(apiKey: ""))
     }
     
     func testLoadingPlist() throws {
-        let expectedHappyConfig = try TjekAPI.Config(apiKey: "<sdk-demo api key>", apiSecret: "<sdk-demo api secret>", clientVersion: "a.b.c", baseURL: URL(string: "https://squid-api.tjek.com")!)
+        let expectedHappyConfig = try TjekAPI.Config(apiKey: "<sdk-demo api key>", clientVersion: "a.b.c", baseURL: URL(string: "https://squid-api.tjek.com")!)
         let testBundle = Bundle.tjekAPITests
         // try to load the updated config
         let happyConfig = try TjekAPI.Config.loadFromPlist(inBundle: testBundle, clientVersion: "a.b.c")
@@ -50,7 +46,7 @@ class TjekAPIConfigTests: XCTestCase {
         // test legacy config file
         let legacyFilePath = try XCTUnwrap(testBundle.url(forResource: "ShopGunSDK-Config.plist", withExtension: nil))
         let legacyConfig = try TjekAPI.Config.load(fromLegacyPlist: legacyFilePath, clientVersion: "5.6.7")
-        let expectedLegacyConfig = try TjekAPI.Config(apiKey: "<legacy api key>", apiSecret: "<legacy api secret>", clientVersion: "5.6.7", baseURL: URL(string: "https://squid-api.tjek.com")!)
+        let expectedLegacyConfig = try TjekAPI.Config(apiKey: "<legacy api key>", clientVersion: "5.6.7", baseURL: URL(string: "https://squid-api.tjek.com")!)
         XCTAssertEqual(legacyConfig, expectedLegacyConfig)
     }
 }


### PR DESCRIPTION
Marks the old the initializers as deprecated.