### PR TITLE
Simplify PublicationOpened events

### DIFF
--- a/Sources/TjekEventsTracker/Event+SDKEvents.swift
+++ b/Sources/TjekEventsTracker/Event+SDKEvents.swift
@@ -275,7 +275,7 @@ extension Event {
      - parameter timestamp: The date that the event occurred. Defaults to now.
      - parameter tokenizer: A Tokenizer for generating the unique view token. Defaults to the shared EventsTrackers's viewTokenizer.
      */
-    @available(*, deprecated, renamed: "incitoPublicationOpened(_:isAlsoPagedPublication:timestamp:tokenizer:)")
+    @available(*, deprecated, renamed: "incitoPublicationOpened(_:timestamp:tokenizer:)")
     internal static func incitoPublicationOpened(
         _ incitoId: PublicationId,
         pagedPublicationId: PublicationId?,
@@ -299,14 +299,12 @@ extension Event {
     
     internal static func incitoPublicationOpened(
         _ incitoPublicationId: PublicationId,
-        isAlsoPagedPublication: Bool,
         timestamp: Date = Date(),
         tokenizer: Tokenizer = TjekEventsTracker.shared.viewTokenizer.tokenize
     ) -> Event {
         
         let payload: PayloadType = [
-            "ip.id": .string(incitoPublicationId.rawValue),
-            "ip.paged": .bool(isAlsoPagedPublication)
+            "ip.id": .string(incitoPublicationId.rawValue)
         ]
         
         let event = Event(timestamp: timestamp,
@@ -406,7 +404,7 @@ extension Event {
         return pagedPublicationPageOpened(publicationId, pageNumber: pageNumber, timestamp: Date())
     }
     
-    @available(*, deprecated, renamed: "incitoPublicationOpened(_:isAlsoPagedPublication:)")
+    @available(*, deprecated, renamed: "incitoPublicationOpened(_:)")
     public static func incitoPublicationOpened(
         _ incitoId: PublicationId,
         pagedPublicationId: PublicationId?
@@ -418,13 +416,19 @@ extension Event {
         )
     }
     
+    @available(*, deprecated, renamed: "incitoPublicationOpened(_:)")
     public static func incitoPublicationOpened(
         _ incitoPublicationId: PublicationId,
         isAlsoPagedPublication: Bool
     ) -> Event {
+        return incitoPublicationOpened(incitoPublicationId)
+    }
+    
+    public static func incitoPublicationOpened(
+        _ incitoPublicationId: PublicationId
+    ) -> Event {
         return incitoPublicationOpened(
             incitoPublicationId,
-            isAlsoPagedPublication: isAlsoPagedPublication,
             timestamp: Date()
         )
     }

--- a/Sources/TjekPublicationViewer/IncitoPublication/IncitoLoaderViewController+v4APILoader.swift
+++ b/Sources/TjekPublicationViewer/IncitoPublication/IncitoLoaderViewController+v4APILoader.swift
@@ -103,17 +103,22 @@ extension IncitoAPIQuery.DeviceCategory {
 
 extension IncitoLoaderViewController {
     
-    private func load(
-        incitoPropertyLoader: FutureResult<(publicationId: PublicationId, isAlsoPagedPublication: Bool)>,
-        featureLabelWeights: [String: Double],
-        apiClient: TjekAPI,
+    public func load(
+        publicationId: PublicationId,
+        featureLabelWeights: [String: Double] = [:],
+        apiClient: TjekAPI = .shared,
+        publicationLoaded: ((Result<Publication_v2, Error>) -> Void)? = nil,
         completion: ((Result<(viewController: IncitoViewController, firstSuccessfulLoad: Bool), Error>) -> Void)? = nil
     ) {
         var hasLoadedIncito: Bool = false
-        var eventTriggeredForId: PublicationId? = nil
         
-        // every time the loader is called, fetch the width of the screen
-        let incitoLoaderBuilder: (PublicationId) -> Future<Result<IncitoDocument, Error>> = { [weak self] incitoId in
+        if TjekEventsTracker.isInitialized {
+            TjekEventsTracker.shared.trackEvent(
+                .incitoPublicationOpened(publicationId)
+            )
+        }
+        
+        let loader = IncitoLoader { [weak self] callback in
             Future<IncitoAPIQuery>(work: { [weak self] in
                 let viewWidth = Int(self?.view.frame.size.width ?? 0)
                 let windowWidth = Int(self?.view.window?.frame.size.width ?? 0)
@@ -121,7 +126,7 @@ extension IncitoLoaderViewController {
                 let minWidth = 100
                 // build the query on the main queue.
                 return IncitoAPIQuery(
-                    id: incitoId,
+                    id: publicationId,
                     deviceCategory: .init(device: .current),
                     orientation: .vertical,
                     pointer: .coarse,
@@ -137,26 +142,6 @@ extension IncitoLoaderViewController {
                 .flatMap({ query in apiClient.send(query.apiRequest) })
                 .eraseToAnyError()
 //                .measure(print: " 🌈 Incito Fully Loaded")
-        }
-        
-        // make a loader that first fetches the publication, then gets the incito id from that publication, then calls the graphLoader with that incitoId
-        let loader = IncitoLoader { callback in
-            incitoPropertyLoader
-                .observeResultSuccess({
-                    if eventTriggeredForId != $0.publicationId && TjekEventsTracker.isInitialized {
-                        eventTriggeredForId = $0.publicationId
-                        
-                        TjekEventsTracker.shared.trackEvent(
-                            .incitoPublicationOpened(
-                                $0.publicationId,
-                                isAlsoPagedPublication: $0.isAlsoPagedPublication
-                            )
-                        )
-                    }
-                })
-                .flatMapResult({
-                    incitoLoaderBuilder($0.publicationId)
-                })
                 .run(callback)
         }
         
@@ -173,47 +158,6 @@ extension IncitoLoaderViewController {
     }
     
     public func load(
-        publicationId: PublicationId,
-        featureLabelWeights: [String: Double] = [:],
-        apiClient: TjekAPI = .shared,
-        publicationLoaded: ((Result<Publication_v2, Error>) -> Void)? = nil,
-        completion: ((Result<(viewController: IncitoViewController, firstSuccessfulLoad: Bool), Error>) -> Void)? = nil
-    ) {
-        
-        let incitoPropertyLoader: FutureResult<(publicationId: PublicationId, isAlsoPagedPublication: Bool)> = apiClient.send(.getPublication(withId: publicationId))
-            .eraseToAnyError()
-            .observe({ publicationLoaded?($0) })
-            .map({
-                switch $0 {
-                case let .success(publication):
-                    if publication.hasIncitoPublication {
-                        return .success((publicationId: publication.id, isAlsoPagedPublication: publication.hasPagedPublication))
-                    } else {
-                        return .failure(IncitoAPIQueryError.notAnIncitoPublication)
-                    }
-                case let .failure(err):
-                    return .failure(err)
-                }
-            })
-        
-        self.load(
-            incitoPropertyLoader: incitoPropertyLoader,
-            featureLabelWeights: featureLabelWeights,
-            apiClient: apiClient,
-            completion: completion
-        )
-    }
-    
-    /**
-     Will start loading the incito specified by the publication, using the graphClient.
-     
-     During the loading process (but before the incito is completely parsed) the businessLoaded callback will be called, containing the GraphBusiness object associated with the Incito. You can use this to customize the screen (bg color etc) before the incito is fully loaded.
-     
-     Once the incito is fully parsed, and the view is ready to be shown, the completion handler will be called.
-     
-     If you specify a `lastReadPosition` it will scroll to this location once loading finishes. This is a 0-1 %, accessible via the `scrollProgress` property of the IncitoViewController.
-     */
-    public func load(
         publication: Publication_v2,
         featureLabelWeights: [String: Double] = [:],
         apiClient: TjekAPI = .shared,
@@ -229,7 +173,7 @@ extension IncitoLoaderViewController {
         }
         
         self.load(
-            incitoPropertyLoader: .init(value: .success((publication.id, publication.hasPagedPublication))),
+            publicationId: publication.id,
             featureLabelWeights: featureLabelWeights,
             apiClient: apiClient,
             completion: completion

--- a/Sources/TjekPublicationViewer/PagedPublication/PagedPublicationView.swift
+++ b/Sources/TjekPublicationViewer/PagedPublication/PagedPublicationView.swift
@@ -88,6 +88,14 @@ public class PagedPublicationView: UIView {
             
             s.delegate?.didStartReloading(in: s)
             
+            // successful reload, event handler can now be created if needed (if new publication, or we havnt called it yet)
+            if let tracker: TjekEventsTracker = (TjekEventsTracker.isInitialized ? TjekEventsTracker.shared : nil),
+               (self?.eventHandler == nil || self?.eventHandler?.publicationId != publicationId) {
+                self?.eventHandler = EventsHandler(eventsTracker: tracker, publicationId: publicationId)
+                
+                self?.eventHandler?.didOpenPublication()
+            }
+            
             // do the loading
             s.dataLoader.startLoading(publicationId: publicationId, publicationLoaded: { [weak self] in self?.publicationDidLoad(forId: publicationId, result: $0) },
                                       pagesLoaded: { [weak self] in self?.pagesDidLoad(forId: publicationId, result: $0) },
@@ -317,14 +325,7 @@ public class PagedPublicationView: UIView {
             self.coreProperties = (pageCount: publicationModel.pageCount,
                                    bgColor: bgColor,
                                    aspectRatio: publicationModel.aspectRatio)
-
-            // successful reload, event handler can now be created if needed (if new publication, or we havnt called it yet)
-            if let tracker: TjekEventsTracker = (TjekEventsTracker.isInitialized ? TjekEventsTracker.shared : nil),
-               (self.eventHandler == nil || self.eventHandler?.publicationId != publicationId) {
-                self.eventHandler = EventsHandler(eventsTracker: tracker, publicationId: publicationId)
-            }
             
-            self.eventHandler?.didOpenPublication()
             self.eventHandler?.didOpenPublicationPages(currentPageIndexes)
             
             delegate?.didLoad(publication: publicationModel, in: self)


### PR DESCRIPTION
Unifies the `[Incito|Paged]PublicationOpened` events, so that they are both called as soon as the screen appears, rather than waiting for the model to load or the view to render.

Related to https://github.com/shopgun/TjekTeams/issues/274